### PR TITLE
feat: Quotememtum → InspireMe 리네이밍

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fkenshin579%2Fapp-quotememtum&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fkenshin579%2Finspireme.chrome&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 
-# Quotememtum
+# InspireMe Chrome Extension
 
 새 탭에서 매일 영감을 주는 명언을 만나보세요.
 

--- a/docs/start/3_chrome_implementation.md
+++ b/docs/start/3_chrome_implementation.md
@@ -1,11 +1,11 @@
-# Quotememtum Chrome Extension 현대화 - 구현 문서
+# InspireMe Chrome Extension 현대화 - 구현 문서
 
 ## 1. 프로젝트 초기화
 
 ### WXT + React + TypeScript 셋업
 
 ```bash
-cd app-quotememtum
+cd inspireme.chrome
 # 기존 소스 백업 후 WXT 프로젝트 초기화
 pnpm dlx wxt@latest init . --template react
 ```
@@ -17,7 +17,7 @@ import { defineConfig } from 'wxt';
 export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
-    name: 'Quotememtum',
+    name: 'InspireMe',
     version: '2.0.0',
     description: '새 탭에서 매일 영감을 주는 명언을 만나보세요',
     permissions: ['storage'],
@@ -51,7 +51,7 @@ export default defineConfig({
 ## 2. 디렉토리 구조
 
 ```
-app-quotememtum/
+inspireme.chrome/
 ├── src/
 │   ├── entrypoints/
 │   │   └── newtab/               # WXT newtab 엔트리포인트
@@ -244,7 +244,7 @@ export async function fetchRandomPhoto(): Promise<UnsplashPhoto> {
 ### lib/storage.ts
 
 ```typescript
-const PREFIX = 'QMT';
+const PREFIX = 'IM';
 
 function key(name: string): string {
   return `${PREFIX}_${name}`;

--- a/docs/start/3_chrome_prd.md
+++ b/docs/start/3_chrome_prd.md
@@ -1,4 +1,4 @@
-# Quotememtum Chrome Extension 현대화 PRD
+# InspireMe Chrome Extension 현대화 PRD
 
 ## 1. 현재 상태 분석
 
@@ -192,7 +192,7 @@ Authorization: Bearer im_live_xxxx...
 ```json
 {
   "manifest_version": 3,
-  "name": "Quotememtum",
+  "name": "InspireMe",
   "version": "2.0.0",
   "description": "새 탭에서 매일 영감을 주는 명언을 만나보세요",
   "chrome_url_overrides": {
@@ -253,7 +253,7 @@ Authorization: Bearer im_live_xxxx...
 ## 7. 프로젝트 구조 (안)
 
 ```
-app-quotememtum/
+inspireme.chrome/
 ├── src/
 │   ├── entrypoints/
 │   │   └── newtab/            # WXT 컨벤션: 새 탭 페이지
@@ -356,8 +356,8 @@ app-quotememtum/
 - CI/CD: GitHub Actions로 자동 빌드/배포
 
 ### 9.6 기존 프로젝트 처리
-- 기존 `app-quotememtum/` 디렉토리에서 작업 (덮어쓰기)
-- 또는 `app-quotememtum-v2/`로 새로 시작 후 안정화되면 교체
+- 기존 `inspireme.chrome/` 디렉토리에서 작업 (덮어쓰기)
+- 또는 `inspireme.chrome-v2/`로 새로 시작 후 안정화되면 교체
 - → **기존 디렉토리에서 진행 권장** (git 히스토리 유지)
 
 ### 9.7 모니터링/분석

--- a/docs/start/3_chrome_todo.md
+++ b/docs/start/3_chrome_todo.md
@@ -1,4 +1,4 @@
-# Quotememtum Chrome Extension 현대화 - TODO
+# InspireMe Chrome Extension 현대화 - TODO
 
 ## Phase 1: 프로젝트 초기화
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quotememtum",
+  "name": "inspireme-chrome",
   "description": "새 탭에서 매일 영감을 주는 명언을 만나보세요",
   "private": true,
   "version": "2.0.0",

--- a/src/components/WallpaperInfo.tsx
+++ b/src/components/WallpaperInfo.tsx
@@ -7,8 +7,8 @@ interface WallpaperInfoProps {
 export function WallpaperInfo({ photo }: WallpaperInfoProps) {
   if (!photo) return null;
 
-  const photographerUrl = `${photo.user.links.html}?utm_source=quotememtum&utm_medium=referral`;
-  const unsplashUrl = 'https://unsplash.com/?utm_source=quotememtum&utm_medium=referral';
+  const photographerUrl = `${photo.user.links.html}?utm_source=inspireme&utm_medium=referral`;
+  const unsplashUrl = 'https://unsplash.com/?utm_source=inspireme&utm_medium=referral';
 
   return (
     <div className="text-xs text-white/60 drop-shadow-md">

--- a/src/components/settings/About.tsx
+++ b/src/components/settings/About.tsx
@@ -2,7 +2,7 @@ export function About() {
   return (
     <div className="space-y-4 text-sm text-gray-300">
       <div>
-        <h3 className="mb-1 font-medium text-white">Quotememtum</h3>
+        <h3 className="mb-1 font-medium text-white">InspireMe</h3>
         <p>새 탭에서 매일 영감을 주는 명언을 만나보세요.</p>
       </div>
 
@@ -12,7 +12,7 @@ export function About() {
 
       <div className="space-y-1">
         <a
-          href="https://github.com/kenshin579/app-quotememtum"
+          href="https://github.com/kenshin579/inspireme.chrome"
           target="_blank"
           rel="noopener noreferrer"
           className="block underline hover:text-white"

--- a/src/entrypoints/newtab/index.html
+++ b/src/entrypoints/newtab/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quotememtum</title>
+    <title>InspireMe</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const STORAGE_PREFIX = 'QMT';
+export const STORAGE_PREFIX = 'IM';
 
 export const INSPIREME_BASE_URL = 'https://inspire-me.advenoh.pe.kr';
 export const INSPIREME_API_URL = `${INSPIREME_BASE_URL}/api/v1`;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   srcDir: 'src',
   modules: ['@wxt-dev/module-react'],
   manifest: {
-    name: 'Quotememtum',
+    name: 'InspireMe',
     version: '2.0.0',
     description: '새 탭에서 매일 영감을 주는 명언을 만나보세요',
     permissions: ['storage'],


### PR DESCRIPTION
## Summary
- 프로젝트 내부 이름을 `Quotememtum` → `InspireMe`로 일괄 변경
- package.json, manifest, 페이지 타이틀, About, GitHub URL, Unsplash utm_source, STORAGE_PREFIX, README, docs 문서

## Test plan
- [x] `pnpm build` 빌드 성공 확인
- [ ] Chrome sideload 후 확장 프로그램 이름 "InspireMe" 표시 확인
- [ ] 설정 > About에서 프로젝트명 및 GitHub 링크 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)