### PR TITLE
Makefile + release 스크립트 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: help dev build zip tag
+
+# ========================================
+# 도움말
+# ========================================
+
+help:
+	@echo "InspireMe Chrome Extension 명령어"
+	@echo ""
+	@echo "개발:"
+	@echo "  dev      개발 서버 실행 (HMR)"
+	@echo "  build    프로덕션 빌드"
+	@echo "  zip      빌드 + zip 생성"
+	@echo ""
+	@echo "릴리스:"
+	@echo "  make tag patch|minor|major   버전 태그 + GitHub Release (zip 첨부)"
+
+# ========================================
+# 개발
+# ========================================
+
+dev:
+	@pnpm dev
+
+build:
+	@pnpm build
+
+zip:
+	@pnpm zip
+
+# ========================================
+# 릴리스
+# ========================================
+
+# 태그 및 릴리스 (인자: patch, minor, major)
+# 사용법: make tag patch / make tag minor / make tag major
+tag:
+	@./scripts/release.sh $(filter-out $@,$(MAKECMDGOALS))
+
+# 인자를 타겟으로 인식하지 않도록 처리
+%:
+	@:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+VERSION_TYPE=${1:-patch}
+
+# package.json에서 현재 버전 읽기 (Chrome extension 버전의 source of truth)
+CURRENT_VERSION=$(sed -n 's/.*"version": "\(.*\)".*/\1/p' package.json)
+
+# 버전 파싱
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# 버전 범프
+case $VERSION_TYPE in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *) echo "Usage: $0 [patch|minor|major]"; exit 1 ;;
+esac
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+NEW_VERSION_NUM="${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Current version: v${CURRENT_VERSION}"
+echo "New version: $NEW_VERSION"
+
+# package.json 버전 업데이트
+sed -i '' "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION_NUM}\"/" package.json
+echo "Updated package.json to ${NEW_VERSION_NUM}"
+
+# 이전 zip 정리 후 빌드
+rm -f .output/*-chrome.zip
+echo "Building and zipping extension..."
+pnpm zip
+
+ZIP_FILE=$(ls .output/*-chrome.zip 2>/dev/null | head -1)
+
+if [ -z "$ZIP_FILE" ]; then
+  echo "Error: zip file not found in .output/"
+  exit 1
+fi
+
+echo "Created: $ZIP_FILE"
+
+# 버전 변경 커밋
+git add package.json
+git commit -m "[release] ${NEW_VERSION}"
+
+# Git 태그 생성 및 푸시
+git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+git push origin HEAD
+git push origin "$NEW_VERSION"
+
+# GitHub 릴리스 생성 (zip 첨부)
+gh release create "$NEW_VERSION" "$ZIP_FILE" \
+  --title "$NEW_VERSION" \
+  --generate-notes
+
+echo ""
+echo "Released: $NEW_VERSION"
+echo "Asset: $ZIP_FILE"


### PR DESCRIPTION
## Summary
- `make tag patch/minor/major` 로 버전 범프 + 빌드 + GitHub Release 생성
- package.json 기준 버전 관리, zip 파일을 Release asset으로 첨부
- 사용자는 Release 페이지에서 zip 다운로드 → 압축해제 → Chrome 로드로 설치 가능

## Test plan
- [x] 버전 파싱 (package.json → 2.0.0) 정상
- [x] patch/minor/major 범프 정상
- [x] sed 버전 교체 정상
- [x] pnpm zip 빌드 + zip 생성 정상 (460KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)