### PR TITLE
wxt.config.ts 버전 하드코딩 제거 + release 캐시 정리

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -27,8 +27,8 @@ echo "New version: $NEW_VERSION"
 sed -i '' "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION_NUM}\"/" package.json
 echo "Updated package.json to ${NEW_VERSION_NUM}"
 
-# 이전 zip 정리 후 빌드
-rm -f .output/*-chrome.zip
+# 빌드 캐시 정리 후 빌드 (버전이 manifest와 zip 파일명에 반영되도록)
+rm -rf .output
 echo "Building and zipping extension..."
 pnpm zip
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
     name: 'InspireMe',
-    version: '2.0.0',
     description: '새 탭에서 매일 영감을 주는 명언을 만나보세요',
     permissions: ['storage'],
     host_permissions: [


### PR DESCRIPTION
## Summary
- `wxt.config.ts`에서 `version: '2.0.0'` 하드코딩 제거 → package.json에서 자동 읽도록 변경
- `release.sh`에서 `.output` 전체 정리하여 빌드 캐시로 인한 버전 불일치 해결

## Test plan
- [x] `pnpm zip` 시 package.json 버전(2.0.1)이 manifest + zip 파일명에 반영됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)