### PR TITLE
명언 폰트 및 글자 크기 설정 추가

### DIFF
--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -4,9 +4,11 @@ import type { Quote as QuoteType } from '../types/quote';
 interface QuoteProps {
   quote: QuoteType | null;
   loading: boolean;
+  fontFamily?: string;
+  fontSize?: number;
 }
 
-export function Quote({ quote, loading }: QuoteProps) {
+export function Quote({ quote, loading, fontFamily, fontSize = 36 }: QuoteProps) {
   if (loading) {
     return (
       <div className="text-center text-white/50 animate-pulse">
@@ -25,8 +27,14 @@ export function Quote({ quote, loading }: QuoteProps) {
     ? `${INSPIREME_BASE_URL}/authors/${quote.authorSlug}`
     : undefined;
 
+  const quoteStyle: React.CSSProperties = {
+    fontFamily: fontFamily || undefined,
+    fontSize: `${fontSize}px`,
+    lineHeight: 1.6,
+  };
+
   const quoteContent = (
-    <p className="text-4xl font-light leading-relaxed drop-shadow-lg max-w-3xl">
+    <p className="font-light drop-shadow-lg max-w-3xl" style={quoteStyle}>
       &ldquo;{quote.content}&rdquo;
     </p>
   );
@@ -41,7 +49,7 @@ export function Quote({ quote, loading }: QuoteProps) {
         quoteContent
       )}
 
-      <p className="mt-4 text-xl text-white/80 drop-shadow-md">
+      <p className="mt-4 text-xl text-white/80 drop-shadow-md" style={{ fontFamily: fontFamily || undefined }}>
         —{' '}
         {authorUrl ? (
           <a href={authorUrl} className="hover:underline">{quote.author}</a>

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -1,4 +1,5 @@
-import type { UserSettings, ClockFormat, QuoteMode, Language } from '../../types/settings';
+import type { UserSettings, ClockFormat, QuoteMode, Language, QuoteFont } from '../../types/settings';
+import { QUOTE_FONTS } from '../../types/settings';
 
 interface GeneralSettingsProps {
   settings: UserSettings;
@@ -45,6 +46,36 @@ export function GeneralSettings({ settings, onUpdate }: GeneralSettingsProps) {
             className="w-16 rounded bg-gray-700 px-2 py-1.5 text-center text-sm text-white [&::-webkit-inner-spin-button]:appearance-auto [&::-webkit-outer-spin-button]:appearance-auto"
           />
           <span className="text-sm text-gray-400">시간</span>
+        </div>
+      </SettingRow>
+
+      <SettingRow label="명언 폰트">
+        <select
+          value={settings.quoteFont}
+          onChange={(e) => onUpdate({ quoteFont: e.target.value as QuoteFont })}
+          className="rounded bg-gray-700 px-3 py-1.5 text-sm text-white"
+        >
+          {QUOTE_FONTS.map((f) => (
+            <option key={f.value} value={f.value}>{f.label}</option>
+          ))}
+        </select>
+      </SettingRow>
+
+      <SettingRow label="명언 글자 크기">
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={16}
+            max={64}
+            step={2}
+            value={settings.quoteFontSize}
+            onChange={(e) => {
+              const v = Math.min(64, Math.max(16, Number(e.target.value) || 36));
+              onUpdate({ quoteFontSize: v });
+            }}
+            className="w-16 rounded bg-gray-700 px-2 py-1.5 text-center text-sm text-white [&::-webkit-inner-spin-button]:appearance-auto [&::-webkit-outer-spin-button]:appearance-auto"
+          />
+          <span className="text-sm text-gray-400">px</span>
         </div>
       </SettingRow>
 

--- a/src/entrypoints/newtab/App.tsx
+++ b/src/entrypoints/newtab/App.tsx
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { useQuote } from '../../hooks/useQuote';
 import { useClock } from '../../hooks/useClock';
 import { useBackground } from '../../hooks/useBackground';
-
+import { useGoogleFont, getQuoteFontFamily } from '../../hooks/useGoogleFont';
 import { Background } from '../../components/Background';
 import { Clock } from '../../components/Clock';
 import { Quote } from '../../components/Quote';
@@ -17,6 +17,8 @@ export default function App() {
   const { quote, loading: quoteLoading } = useQuote(settings);
   const { formatted, dateStr } = useClock(settings.clockFormat);
   const { bgUrl, photoInfo } = useBackground();
+  useGoogleFont(settings.quoteFont);
+  const quoteFontFamily = getQuoteFontFamily(settings.quoteFont);
   const [showSettings, setShowSettings] = useState(false);
 
   useEffect(() => {
@@ -46,6 +48,8 @@ export default function App() {
         <Quote
           quote={quote}
           loading={quoteLoading}
+          fontFamily={quoteFontFamily}
+          fontSize={settings.quoteFontSize}
         />
       </div>
 

--- a/src/hooks/useGoogleFont.ts
+++ b/src/hooks/useGoogleFont.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { QUOTE_FONTS, type QuoteFont } from '../types/settings';
+
+const GOOGLE_FONT_NAMES: Record<string, string> = {
+  'noto-serif-kr': 'Noto+Serif+KR:wght@300;400',
+  'nanum-myeongjo': 'Nanum+Myeongjo:wght@400;700',
+  'gowun-batang': 'Gowun+Batang:wght@400;700',
+  'nanum-gothic': 'Nanum+Gothic:wght@400;700',
+  'gaegu': 'Gaegu:wght@300;400',
+};
+
+export function useGoogleFont(font: QuoteFont) {
+  useEffect(() => {
+    if (font === 'system') return;
+
+    const googleName = GOOGLE_FONT_NAMES[font];
+    if (!googleName) return;
+
+    const id = `google-font-${font}`;
+    if (document.getElementById(id)) return;
+
+    const link = document.createElement('link');
+    link.id = id;
+    link.rel = 'stylesheet';
+    link.href = `https://fonts.googleapis.com/css2?family=${googleName}&display=swap`;
+    document.head.appendChild(link);
+  }, [font]);
+}
+
+export function getQuoteFontFamily(font: QuoteFont): string {
+  const found = QUOTE_FONTS.find((f) => f.value === font);
+  return found?.family || '';
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -3,6 +3,17 @@ export type QuoteMode = 'qotd' | 'random';
 export type Language = 'ko' | 'en';
 export type BackgroundSource = 'unsplash' | 'qotd' | 'both';
 
+export const QUOTE_FONTS = [
+  { value: 'system', label: '시스템 기본', family: '' },
+  { value: 'noto-serif-kr', label: 'Noto Serif Korean', family: "'Noto Serif KR', serif" },
+  { value: 'nanum-myeongjo', label: '나눔명조', family: "'Nanum Myeongjo', serif" },
+  { value: 'gowun-batang', label: '고운바탕', family: "'Gowun Batang', serif" },
+  { value: 'nanum-gothic', label: '나눔고딕', family: "'Nanum Gothic', sans-serif" },
+  { value: 'gaegu', label: '개구', family: "'Gaegu', cursive" },
+] as const;
+
+export type QuoteFont = (typeof QUOTE_FONTS)[number]['value'];
+
 export interface UserSettings {
   clockFormat: ClockFormat;
   quoteFrequency: number;
@@ -10,6 +21,8 @@ export interface UserSettings {
   language: Language;
   darkMode: boolean;
   backgroundSource: BackgroundSource;
+  quoteFont: QuoteFont;
+  quoteFontSize: number;
 }
 
 export const DEFAULT_SETTINGS: UserSettings = {
@@ -19,4 +32,6 @@ export const DEFAULT_SETTINGS: UserSettings = {
   language: 'ko',
   darkMode: false,
   backgroundSource: 'unsplash',
+  quoteFont: 'noto-serif-kr',
+  quoteFontSize: 36,
 };


### PR DESCRIPTION
## Summary
- 일반 설정에 명언 폰트 선택 추가 (6종)
  - 시스템 기본, Noto Serif Korean, 나눔명조, 고운바탕, 나눔고딕, 개구
  - Google Fonts 동적 로드 (선택한 폰트만)
- 명언 글자 크기 설정 추가 (16~64px, 기본 36px, up/down 화살표)

## Test plan
- [x] `pnpm build` 정상
- [x] `pnpm lint` 에러 없음
- [ ] 설정에서 폰트 변경 시 명언 텍스트에 즉시 반영
- [ ] 글자 크기 변경 시 즉시 반영
- [ ] 새 탭 재열기 시 설정 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)