### PR TITLE
[#버그] 오늘의 명언 타임존 캐시 버그 수정

### DIFF
--- a/src/hooks/useQuote.ts
+++ b/src/hooks/useQuote.ts
@@ -11,12 +11,6 @@ interface CachedQuote {
   quoteMode: QuoteMode;
 }
 
-function isDayChanged(timestamp: number): boolean {
-  const cached = new Date(timestamp);
-  const now = new Date();
-  return cached.toDateString() !== now.toDateString();
-}
-
 export function useQuote(settings: UserSettings) {
   const [quote, setQuote] = useState<Quote | null>(null);
   const [loading, setLoading] = useState(true);
@@ -34,21 +28,9 @@ export function useQuote(settings: UserSettings) {
     const cached = await storage.get<CachedQuote>('quote');
     const modeChanged = cached?.quoteMode !== settings.quoteMode;
 
-    // 1) 캐시 유효 판정 — 모드별 분기
-    if (cached && !modeChanged) {
-      if (settings.quoteMode === 'qotd') {
-        // 오늘의 명언: 같은 날이면 캐시 표시 후 종료 (quoteFrequency 무시)
-        if (!isDayChanged(cached.timestamp)) {
-          setQuote(cached.quote);
-          setLoading(false);
-          return;
-        }
-      }
-      // 랜덤 명언: early return 없음 → 항상 SWR 진행
-    }
-
-    // 2) stale 데이터 또는 fallback을 즉시 표시 (SWR)
+    // 1) stale 데이터 또는 fallback을 즉시 표시 (SWR)
     //    - 모드 전환 시: 이전 모드 캐시 대신 fallback 사용
+    //    - 날짜 비교 대신 항상 백그라운드 API 호출로 최신 명언 감지 (타임존 의존 제거)
     if (cached && !modeChanged) {
       setQuote(cached.quote);
     } else {
@@ -56,7 +38,7 @@ export function useQuote(settings: UserSettings) {
     }
     setLoading(false);
 
-    // 3) 백그라운드 API 호출 → 응답 시 교체
+    // 2) 백그라운드 API 호출 → 응답 시 교체 (값이 같으면 React가 리렌더 생략)
     try {
       let newQuote: Quote;
       if (settings.quoteMode === 'qotd') {


### PR DESCRIPTION
## 문제

크롬 확장 새 탭이 **오늘 명언 대신 어제 명언을 하루 종일 고정 표시**하는 버그.
(웹사이트·백엔드 API는 정상 — 같은 시점에 오늘 명언을 정상 반환)

## 원인

명언 선택 주체인 백엔드와 클라이언트 캐시의 "오늘" 기준이 어긋남:

| 주체 | "오늘" 판정 기준 |
|---|---|
| 백엔드 (명언 선택) | **UTC** 자정 (= KST 오전 9시 전환) |
| 크롬 확장 (`isDayChanged`) | **로컬(KST)** 자정 (`toDateString()`) |

KST 0~9시(UTC로는 아직 전날)에 새 탭이 열리면:
1. 백엔드(UTC 기준)가 어제 명언을 반환
2. 캐시에 `{ 명언: 어제것, timestamp: 오늘 }`로 저장 (내용은 어제, 날짜 도장은 오늘)
3. 이후 KST 9시가 지나도 `isDayChanged`가 "같은 날"로 판정 → API 재호출 차단(early return) → 어제 명언 고정

## 수정

- `isDayChanged` 날짜 비교 함수 제거 (타임존 의존 제거)
- qotd 모드 early-return 제거 → **qotd도 random과 동일하게 항상 백그라운드 API 호출**
- 응답 값으로 갱신(동일 값이면 React가 리렌더 생략 → "값 변경 감지" 효과)

날짜 계산을 클라이언트에서 없애고 백엔드를 진실의 원천으로 삼아 타임존 어긋남을 원천 제거. 한국 밖에서도 안전. (전환 시각은 백엔드 기준 KST 오전 9시)

## Test plan

- [x] `pnpm build` 통과
- [ ] 새 탭 열면 캐시 명언 → 즉시 오늘 명언으로 교체 확인
- [ ] 캐시가 어제로 굳은 상태에서 새 탭 한 번 열면 오늘 명언으로 갱신 확인

> 참고: `react-hooks/set-state-in-effect` lint 에러 2건(`useQuote.ts`, `useBackground.ts`)은 master에 기존부터 존재하던 것으로, 이번 변경과 무관하며 스코프 밖입니다.